### PR TITLE
Player death & respawn. Fixed return error.

### DIFF
--- a/application/bin/application.cpp
+++ b/application/bin/application.cpp
@@ -14,6 +14,9 @@ int main(int argc, char** argv)
   CameraView view;
   GameLogic logic;
 
+  //added passing window dimensions:
+  logic.dimensions(dim);
+
   view.init();
 
   //create clock

--- a/application/include/GameLogic.h
+++ b/application/include/GameLogic.h
@@ -11,6 +11,7 @@ class GameLogic {
     void togglePause();
     void generateMap();
     void playGame();
+    void dimensions(sf::Vector2u dim);
     enum GameState {mainMenu, playing, pauseMenu, gameOverMenu};
     GameState getState();
 
@@ -20,6 +21,8 @@ class GameLogic {
 
 private:
     GameState state;
+    //window dimensions
+    sf::Vector2u dim;
 
 };
 

--- a/application/src/GameLogic.cpp
+++ b/application/src/GameLogic.cpp
@@ -5,6 +5,7 @@ GameLogic::GameLogic() {
     state = mainMenu;
     walrus1 = Player();
     walrus2 = Player();
+    sf::Vector2u dim;
 }
 
 void GameLogic::update(float dSec) {
@@ -22,7 +23,12 @@ void GameLogic::update(float dSec) {
         // check collisions
         
         // if player has moved off the screen
-          // trigger their death and respawn both players
+            // trigger their death and respawn both players
+        if (walrus1.getPos().x > dim.x || walrus1.getPos().y > dim.y || walrus1.getPos().x < 0 || walrus1.getPos().y < 0)
+            handlePlayerDeath(1);
+        if (walrus2.getPos().x > dim.x || walrus2.getPos().y > dim.y || walrus2.getPos().x < 0 || walrus2.getPos().y < 0)
+            handlePlayerDeath(2);
+
 
     }
 
@@ -33,9 +39,30 @@ void GameLogic::generateMap() {
   stage.generateMap();
 }
 
-
+/*
+ *1 param: walrus1 died
+ * 2 param: walrus2 died
+ * */
 void GameLogic::handlePlayerDeath(int x) {
 
+    //will have more need for separate cases later on to adjust the screen transition
+	if (x == 1) {
+	    std::cout<<"walrus1 died";
+	}
+	else if (x == 2) {
+	    std::cout<<"walrus2 died";
+	}
+    sf::Vector2f spawn_vector;
+    //below fixes conversion warnings between between Vector2u and Vector2f
+    unsigned int spawn_x = dim.x; unsigned int spawn_y = dim.y;
+    float x_float = (float) spawn_x / 2.0f; float y_float = (float) spawn_y / 2.0f;
+    spawn_vector.x = x_float; spawn_vector.y = y_float;
+
+    walrus1.spawn(spawn_vector);
+    //set walrus2 a tenth of the screen size to the right and a tenth of the screen size down
+    spawn_vector.x += dim.x / 10;
+    spawn_vector.y -= dim.y / 10;
+    walrus2.spawn(spawn_vector);
 }
 
 void GameLogic::togglePause() {
@@ -51,6 +78,10 @@ void GameLogic::playGame() {
     // hardcoded values should change to be relative to window dimension
     walrus1.spawn(sf::Vector2f(1.0,1.0));
     walrus2.spawn(sf::Vector2f(100.0,100.0));
+}
+
+void GameLogic::dimensions(sf::Vector2u dim) {
+    this->dim = dim;
 }
 
 GameLogic::GameState GameLogic::getState() {

--- a/application/src/Stage.cpp
+++ b/application/src/Stage.cpp
@@ -9,5 +9,5 @@ void Stage::generateMap(){
 }
 
 float Stage::getBlockDura(int x, int y){
-
+	return 0.0f;
 }


### PR DESCRIPTION
Added player death and respawn. Currently using the screen boundaries, so added an attribute and method to pass the screen dimensions to GameLogic (and added the one line to do so in application). Set the respawn location to the center of the screen with a small offset for one player (so that they don't spawn on top of each other). Also added a 0.0f return value in Stage.cpp to fix the error that a return value is expected.